### PR TITLE
removed env vars from repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local


### PR DESCRIPTION
In order to create develop environment we need to keep this out of repo. Here's more rationale: https://www.npmjs.com/package/dotenv#should-i-commit-my-env-file