### PR TITLE
Fix ESLint linebreak-style throwing errors

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,7 +15,8 @@
         "ignoreRestSiblings": true,
         "argsIgnorePattern": "^_"
       }
-    ]
+    ],
+    "linebreak-style": "off"
   },
   "env": {
     "jest": true


### PR DESCRIPTION
This rule is problematic for apps that are collaborated on Unix vs Windows systems.
I suggest to remove this rule. 
I am not sure it is very practical anyways.