### PR TITLE
Changed &#926; to Ξ in some cases where encoding breaks

### DIFF
--- a/src/components/views/Donations.jsx
+++ b/src/components/views/Donations.jsx
@@ -219,7 +219,7 @@ class Donations extends Component {
         React.swal({
           title: 'Refund your donation?',
           text: 'Your donation will be cancelled and the a payment will be authorized for you to withdraw your ETH. All withdrawls' +
-          ' must be confirmed for security reasons and may take a day or two. Upon confirmation, your &#926; will be' +
+          ' must be confirmed for security reasons and may take a day or two. Upon confirmation, your Ξ will be' +
           ' transferred to your wallet.',
           icon: 'warning',
           dangerMode: true,

--- a/src/components/views/EditMilestone.jsx
+++ b/src/components/views/EditMilestone.jsx
@@ -395,7 +395,7 @@ class EditMilestone extends Component {
                       placeholder="10"
                       validations="greaterThan:0.1"
                       validationErrors={{
-                        greaterThan: 'Minimum value must be at least &#926;0.1',
+                        greaterThan: 'Minimum value must be at least Ξ 0.1',
                       }}
                       required
                     />


### PR DESCRIPTION
In some cases this was breaking. Seems to be when it is not used directly in JSX but in some other type of function that renders HTML