### PR TITLE
Feature/deployment environment config

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,1 @@
 PORT=3010
-REACT_APP_FEATHERJS_CONNECTION_URL=https://feathers.giveth.io/
-REACT_APP_ETH_NODE_CONNECTION_URL=wss://ethws.giveth.io/

--- a/README.md
+++ b/README.md
@@ -83,19 +83,12 @@ Welcome to the code for Giveth's dapp. This is an open source effort to realize 
 
 ### Run dapp
 1. The Giveth dapp will need to connect to a [feathers-giveth](https://github.com/Giveth/feathers-giveth) server. Follow the feathers-giveth readme instructions to install and run server before proceeding further.
-2. From the giveth-dapp directory, create a filed called `.env.local` with these configs.
-    ```
-    PORT=3010
-    REACT_APP_FEATHERJS_CONNECTION_URL=http://localhost:3030
-    REACT_APP_ETH_NODE_CONNECTION_URL=ws://localhost:8546
-    ```
-
-3. Start the dapp.
+2. Start the dapp.
     ```
     npm start
     ```
-4. Once the dapp is up in your browser, click "Sign In" from the main menu.
-5. For testing locally, choose any of the wallet files found in the `giveth-dapp/keystores/` folder using the wallet password: `password`. **DO NOT USE THESE ON MAINNET ETHEREUM.**
+3. Once the dapp is up in your browser, click "Sign In" from the main menu.
+4. For testing locally, choose any of the wallet files found in the `giveth-dapp/keystores/` folder using the wallet password: `password`. **DO NOT USE THESE ON MAINNET ETHEREUM.**
 
 ### Video Walkthrough
 Video tutorial walkthrough here: https://tinyurl.com/y9lx6jrl
@@ -112,7 +105,7 @@ go to line 300, and add:
 ```
   mangle: {
     safari10: true,
-  },  
+  },
 ```
 
 now the build will work in Safari
@@ -147,7 +140,7 @@ THESE ON MAINNET ETHEREUM.**
 ## Testing Environments and CI
 
 ### master to Ropsten
-1. The Giveth Dapp is auto deployed from the master branch and is live on Ropsten and can be reached here: https://alpha.giveth.io  
+1. The Giveth Dapp is auto deployed from the master branch and is live on Ropsten and can be reached here: https://alpha.giveth.io
 2. In order to use the dapp you will need ETH on the Ropsten network. You can use this faucet to get some: http://faucet.ropsten.be:3001/
 3. "sign up" on the dapp to create an account.
 4. Go to the "wallet" page to see your new address (0x..). Copy and past that address into the faucet link above and you will have Ropsten network ETH for testing.

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -1,0 +1,111 @@
+const {
+  REACT_APP_ENVIRONMENT = 'localhost', // optional
+  REACT_APP_FEATHERJS_CONNECTION_URL,
+  REACT_APP_ETH_NODE_CONNECTION_URL,
+  REACT_APP_LIQUIDPLEDGING_ADDRESS,
+  REACT_APP_DACS_ADDRESS,
+  REACT_APP_CAMPAIGN_FACTORY_ADDRESS,
+  REACT_APP_CAPPED_MILESTONE_ADDRESS,
+  REACT_APP_TOKEN_ADDRESS,
+  REACT_APP_BLOCKEXPLORER,
+} = process.env;
+
+const configurations = {
+  default: {
+    title: 'unknown',
+    liquidPledgingAddress: '0x0',
+    dacsAddress: '0x0',
+    campaignFactoryAddress: '0x0',
+    cappedMilestoneAddress: '0x0',
+    tokenAddress: '0x0',
+    etherscan: '',
+    feathersConnection: 'http://localhost:3030',
+    nodeConnection: 'ws://localhost:8546',
+  },
+  localhost: {
+    title: 'TestRPC',
+    liquidPledgingAddress: '0x254dffcd3277C0b1660F6d42EFbB754edaBAbC2B',
+    dacsAddress: '0xD833215cBcc3f914bD1C9ece3EE7BF8B14f841bb',
+    campaignFactoryAddress: '0x9561C133DD8580860B6b7E504bC5Aa500f0f06a7',
+    cappedMilestoneAddress: '0xe982E462b094850F12AF94d21D470e21bE9D0E9C',
+    tokenAddress: '0x5b1869D9A4C187F2EAa108f3062412ecf0526b24',
+    etherscan: 'https://etherscan.io/', // this won't work, only here so we can see links during development
+    feathersConnection: 'http://localhost:3030',
+    nodeConnection: 'ws://localhost:8546',
+  },
+  develop: {
+    title: 'develop',
+    tokenAddress: '0x7c1a3c53a30407b1047e5eb71d104e8159d0b135',
+    liquidPledgingAddress: '0xE6D8BC43685911AfA2e7E47A88d364bbE9692E19',
+    dacsAddress: '0x0B60e1786D694909d6340E9538d67B79df00dAEf',
+    campaignFactoryAddress: '0xa6E585A9481aF710026993818c0B4c5c32ae2F36',
+    cappedMilestoneAddress: '0xbfb48a8817de49f259a71d2Aa07fC1c95EC24265',
+    etherscan: 'https://rinkeby.etherscan.io/',
+    feathersConnection: 'https://feathers.develop.giveth.io/',
+    nodeConnection: 'wss://rinkeby.giveth.io:8546/',
+  },
+  release: {
+    title: 'release',
+    tokenAddress: '0xe4231c2906acad65e68a932ea4b4bc6c38340f4f',
+    liquidPledgingAddress: '0x54b38a066267072734b4f30e0088722fd0811286',
+    dacsAddress: '0xfbdabecd51eabd205c5dc7cc8c90fe153c42b94d',
+    campaignFactoryAddress: '0x523c1713fa80bb695ca25f85ee4a06533dceef76',
+    cappedMilestoneAddress: '0x9d8a74f03c7765d689171ffb4004670d2bf30a62',
+    etherscan: 'https://rinkeby.etherscan.io/',
+    feathersConnection: 'https://feathers.release.giveth.io/',
+    nodeConnection: 'wss://mew.giveth.io/ws/',
+  },
+  mainnet: {
+    title: 'release',
+    liquidPledgingAddress: '0x3f45D2D5FeB6b4b000d2d3B84442eeDDF54A735a',
+    dacsAddress: '0x79bddecb728afda275923998701bac34d277fb19',
+    campaignFactoryAddress: '0xB22D042896Cd46D073d3Bf7b487522bBe1eeb5E7',
+    cappedMilestoneAddress: '0x61Dc072691041d411bDa8CE5B4090feb45788a8C',
+    etherscan: 'https://etherscan.io/',
+    feathersConnection: 'https://feathers.mainnet.giveth.io/',
+    nodeConnection: 'wss://rinkeby.giveth.io:8546/',
+  },
+  alpha: {
+    title: 'alpha',
+    liquidPledgingAddress: '0x5625220088cA4Df67F15f96595546D10e9970B3A',
+    dacsAddress: '0xc2Cef51f91dE37739F0a105fEDb058E235BB7354',
+    campaignFactoryAddress: '0x2Af51064E9042E62aB09870B4FDe67a1Ba7FEd69',
+    cappedMilestoneAddress: '0x19Bd4E0DEdb9E5Ee9762391893d1f661404b561f',
+    tokenAddress: '0xb991657107F2F12899938B0985572449400C57d5',
+    etherscan: 'https://rinkeby.etherscan.io/',
+    feathersConnection: 'https://feathers.mainnet.giveth.io',
+    nodeConnection: 'wss://rinkeby.giveth.io:8546/',
+  },
+};
+
+// Unknown environment
+if (configurations[REACT_APP_ENVIRONMENT] === undefined)
+  throw new Error(
+    `There is no configuration object for environment: ${REACT_APP_ENVIRONMENT}. Expected REACT_APP_ENVIRONMENT to be empty or one of: ${Object.keys(
+      configurations,
+    )}`,
+  );
+
+// Create config object based on environment setup
+const config = Object.assign(
+  {},
+  configurations.default,
+  configurations[REACT_APP_ENVIRONMENT],
+);
+
+// Overwrite the environment values with parameters
+config.liquidPledgingAddress =
+  REACT_APP_LIQUIDPLEDGING_ADDRESS || config.liquidPledgingAddress;
+config.dacsAddress = REACT_APP_DACS_ADDRESS || config.dacsAddress;
+config.campaignFactoryAddress =
+  REACT_APP_CAMPAIGN_FACTORY_ADDRESS || config.campaignFactoryAddress;
+config.cappedMilestoneAddress =
+  REACT_APP_CAPPED_MILESTONE_ADDRESS || config.cappedMilestoneAddress;
+config.tokenAddress = REACT_APP_TOKEN_ADDRESS || config.tokenAddress;
+config.etherscan = REACT_APP_BLOCKEXPLORER || config.etherscan;
+config.feathersConnection =
+  REACT_APP_FEATHERJS_CONNECTION_URL || config.feathersConnection;
+config.nodeConnection =
+  REACT_APP_ETH_NODE_CONNECTION_URL || config.nodeConnection;
+
+export default config;

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -11,17 +11,6 @@ const {
 } = process.env;
 
 const configurations = {
-  default: {
-    title: 'unknown',
-    liquidPledgingAddress: '0x0',
-    dacsAddress: '0x0',
-    campaignFactoryAddress: '0x0',
-    cappedMilestoneAddress: '0x0',
-    tokenAddress: '0x0',
-    etherscan: '',
-    feathersConnection: 'http://localhost:3030',
-    nodeConnection: 'ws://localhost:8546',
-  },
   localhost: {
     title: 'TestRPC',
     liquidPledgingAddress: '0x254dffcd3277C0b1660F6d42EFbB754edaBAbC2B',
@@ -89,7 +78,7 @@ if (configurations[REACT_APP_ENVIRONMENT] === undefined)
 // Create config object based on environment setup
 const config = Object.assign(
   {},
-  configurations.default,
+  configurations.localhost,
   configurations[REACT_APP_ENVIRONMENT],
 );
 

--- a/src/lib/blockchain/getNetwork.js
+++ b/src/lib/blockchain/getNetwork.js
@@ -3,69 +3,91 @@ import { LPPDacs } from 'lpp-dacs';
 import getWeb3 from './getWeb3';
 
 const networks = {
+  default: {
+    master: {
+      title: 'unknown',
+      liquidPledgingAddress: '0x0',
+      dacsAddress: '0x0',
+      campaignFactoryAddress: '0x0',
+      cappedMilestoneAddress: '0x0',
+      tokenAddress: '0x0',
+      etherscan: '',
+    },
+  },
+  testrpc: {
+    master: {
+      title: 'TestRPC',
+      liquidPledgingAddress: '0x254dffcd3277C0b1660F6d42EFbB754edaBAbC2B',
+      dacsAddress: '0xD833215cBcc3f914bD1C9ece3EE7BF8B14f841bb',
+      campaignFactoryAddress: '0x9561C133DD8580860B6b7E504bC5Aa500f0f06a7',
+      cappedMilestoneAddress: '0xe982E462b094850F12AF94d21D470e21bE9D0E9C',
+      tokenAddress: '0x5b1869D9A4C187F2EAa108f3062412ecf0526b24',
+      etherscan: 'https://etherscan.io/', // this won't work for. only here so we can see links during development
+    },
+  },
   main: {
-    title: 'Main',
-    liquidPledgingAddress: '0x3f45D2D5FeB6b4b000d2d3B84442eeDDF54A735a',
-    dacsAddress: '0x79bddecb728afda275923998701bac34d277fb19',
-    campaignFactoryAddress: '0xB22D042896Cd46D073d3Bf7b487522bBe1eeb5E7',
-    cappedMilestoneAddress: '0x61Dc072691041d411bDa8CE5B4090feb45788a8C',
-    tokenAddress: '0x0',
-    etherscan: 'https://etherscan.io/',
+    master: {
+      title: 'Main',
+      liquidPledgingAddress: '0x3f45D2D5FeB6b4b000d2d3B84442eeDDF54A735a',
+      dacsAddress: '0x79bddecb728afda275923998701bac34d277fb19',
+      campaignFactoryAddress: '0xB22D042896Cd46D073d3Bf7b487522bBe1eeb5E7',
+      cappedMilestoneAddress: '0x61Dc072691041d411bDa8CE5B4090feb45788a8C',
+      etherscan: 'https://etherscan.io/',
+    },
   },
   morden: {
-    title: 'Morden',
-    liquidPledgingAddress: '0x0',
-    dacsAddress: '0x0',
-    campaignFactoryAddress: '0x0',
-    cappedMilestoneAddress: '0x0',
-    tokenAddress: '0x0',
-    etherscan: '',
+    master: {
+      title: 'Morden',
+    },
   },
   ropsten: {
-    title: 'Ropsten',
-    liquidPledgingAddress: '0x0',
-    dacsAddress: '0x0',
-    campaignFactoryAddress: '0x0',
-    cappedMilestoneAddress: '0x0',
-    tokenAddress: '0x0',
-    etherscan: 'https://ropsten.etherscan.io/',
+    master: {
+      title: 'Ropsten',
+      etherscan: 'https://ropsten.etherscan.io/',
+    },
   },
   rinkeby: {
-    title: 'Rinkeby',
-    liquidPledgingAddress: '0x5625220088cA4Df67F15f96595546D10e9970B3A',
-    dacsAddress: '0xc2Cef51f91dE37739F0a105fEDb058E235BB7354',
-    campaignFactoryAddress: '0x2Af51064E9042E62aB09870B4FDe67a1Ba7FEd69',
-    cappedMilestoneAddress: '0x19Bd4E0DEdb9E5Ee9762391893d1f661404b561f',
-    tokenAddress: '0xb991657107F2F12899938B0985572449400C57d5',
-    etherscan: 'https://rinkeby.etherscan.io/',
+    master: {
+      title: 'Rinkeby',
+      liquidPledgingAddress: '0x5625220088cA4Df67F15f96595546D10e9970B3A',
+      dacsAddress: '0xc2Cef51f91dE37739F0a105fEDb058E235BB7354',
+      campaignFactoryAddress: '0x2Af51064E9042E62aB09870B4FDe67a1Ba7FEd69',
+      cappedMilestoneAddress: '0x19Bd4E0DEdb9E5Ee9762391893d1f661404b561f',
+      tokenAddress: '0xb991657107F2F12899938B0985572449400C57d5',
+      etherscan: 'https://rinkeby.etherscan.io/',
+    },
+    develop: {},
+    release: {},
+    alpha: {},
   },
   kovan: {
-    title: 'Kovan',
-    liquidPledgingAddress: '0x0',
-    dacsAddress: '0x0',
-    campaignFactoryAddress: '0x0',
-    cappedMilestoneAddress: '0x0',
-    tokenAddress: '0x0',
-    etherscan: '',
+    master: {
+      title: 'Kovan',
+    },
   },
   giveth: {
-    title: 'Giveth',
-    liquidPledgingAddress: '0x0',
-    dacsAddress: '0x0',
-    campaignFactoryAddress: '0x0',
-    cappedMilestoneAddress: '0x0',
-    tokenAddress: '0x0',
-    etherscan: 'http://network_explorer.giveth.io/',
+    master: {
+      title: 'Giveth',
+      etherscan: 'http://network_explorer.giveth.io/',
+    },
   },
-  default: {
-    title: 'TestRPC',
-    liquidPledgingAddress: '0x254dffcd3277C0b1660F6d42EFbB754edaBAbC2B',
-    dacsAddress: '0xD833215cBcc3f914bD1C9ece3EE7BF8B14f841bb',
-    campaignFactoryAddress: '0x9561C133DD8580860B6b7E504bC5Aa500f0f06a7',
-    cappedMilestoneAddress: '0xe982E462b094850F12AF94d21D470e21bE9D0E9C',
-    tokenAddress: '0x5b1869D9A4C187F2EAa108f3062412ecf0526b24',
-    etherscan: 'https://etherscan.io/', // this won't work for. only here so we can see links during development
-  },
+};
+
+const replaceWitEnvironmentalVars = network => {
+  network.liquidPledgingAddress =
+    process.env.REACT_APP_LIQUIDPLEDGING_ADDRESS ||
+    network.liquidPledgingAddress;
+  network.dacsAddress =
+    process.env.REACT_APP_DACS_ADDRESS || network.dacsAddress;
+  network.campaignFactoryAddress =
+    process.env.REACT_APP_CAMPAIGN_FACTORY_ADDRESS ||
+    network.campaignFactoryAddress;
+  network.cappedMilestoneAddress =
+    process.env.REACT_APP_CAPPED_MILESTONE_ADDRESS ||
+    network.cappedMilestoneAddress;
+  network.tokenAddress =
+    process.env.REACT_APP_TOKEN_ADDRESS || network.tokenAddress;
+  network.etherscan = process.env.REACT_APP_BLOCKEXPLORER || network.etherscan;
 };
 
 let network;
@@ -75,34 +97,56 @@ export default () => {
 
   return getWeb3().then(web3 =>
     web3.eth.net.getId().then(id => {
+      let networkName = 'default';
+      const environmentName = process.env.REACT_APP_ENVIRONMENT || 'master';
       switch (id) {
         case 1:
-          network = Object.assign({}, networks.main);
+          networkName = 'main';
           break;
         case 2:
-          network = Object.assign({}, networks.morden);
+          networkName = 'morden';
           break;
         case 3:
-          network = Object.assign({}, networks.ropsten);
+          networkName = 'ropsten';
           break;
         case 4:
-          network = Object.assign({}, networks.rinkeby);
+          networkName = 'rinkeby';
           break;
         case 33:
-          network = Object.assign({}, networks.giveth);
+          networkName = 'giveth';
           break;
         case 42:
-          network = Object.assign({}, networks.kovan);
+          networkName = 'kovan';
           break;
         default:
-          network = Object.assign({}, networks.default);
+          networkName = 'testrpc';
           break;
       }
+
+      /**
+       * Merge the networks in the following order:
+       *
+       * 1. Default empty networks
+       * 2. Master environment/branch for chosen networks
+       * 3. Chosen environment/branch for chosen network
+       * 4. Network with values defined in the environment variable
+       */
+      network = Object.assign(
+        {},
+        networks.default.master,
+        networks[networkName].master,
+        networks[networkName][environmentName],
+      );
+      replaceWitEnvironmentalVars(network);
+
+      network.environment = environmentName;
       network.liquidPledging = new LiquidPledging(
         web3,
         network.liquidPledgingAddress,
       );
       network.lppDacs = new LPPDacs(web3, network.dacsAddress);
+
+      console.log(network);
       return network;
     }),
   );

--- a/src/lib/blockchain/getNetwork.js
+++ b/src/lib/blockchain/getNetwork.js
@@ -1,154 +1,21 @@
 import { LiquidPledging } from 'giveth-liquidpledging-token';
 import { LPPDacs } from 'lpp-dacs';
 import getWeb3 from './getWeb3';
-
-// The networks look like sparse 2D matrix organised as [networkName][environmentName]
-const networks = {
-  default: {
-    master: {
-      title: 'unknown',
-      liquidPledgingAddress: '0x0',
-      dacsAddress: '0x0',
-      campaignFactoryAddress: '0x0',
-      cappedMilestoneAddress: '0x0',
-      tokenAddress: '0x0',
-      etherscan: '',
-    },
-  },
-  testrpc: {
-    master: {
-      title: 'TestRPC',
-      liquidPledgingAddress: '0x254dffcd3277C0b1660F6d42EFbB754edaBAbC2B',
-      dacsAddress: '0xD833215cBcc3f914bD1C9ece3EE7BF8B14f841bb',
-      campaignFactoryAddress: '0x9561C133DD8580860B6b7E504bC5Aa500f0f06a7',
-      cappedMilestoneAddress: '0xe982E462b094850F12AF94d21D470e21bE9D0E9C',
-      tokenAddress: '0x5b1869D9A4C187F2EAa108f3062412ecf0526b24',
-      etherscan: 'https://etherscan.io/', // this won't work for. only here so we can see links during development
-    },
-  },
-  main: {
-    master: {
-      title: 'Main',
-      liquidPledgingAddress: '0x3f45D2D5FeB6b4b000d2d3B84442eeDDF54A735a',
-      dacsAddress: '0x79bddecb728afda275923998701bac34d277fb19',
-      campaignFactoryAddress: '0xB22D042896Cd46D073d3Bf7b487522bBe1eeb5E7',
-      cappedMilestoneAddress: '0x61Dc072691041d411bDa8CE5B4090feb45788a8C',
-      etherscan: 'https://etherscan.io/',
-    },
-  },
-  morden: {
-    master: {
-      title: 'Morden',
-    },
-  },
-  ropsten: {
-    master: {
-      title: 'Ropsten',
-      etherscan: 'https://ropsten.etherscan.io/',
-    },
-  },
-  rinkeby: {
-    master: {
-      title: 'Rinkeby',
-      liquidPledgingAddress: '0x5625220088cA4Df67F15f96595546D10e9970B3A',
-      dacsAddress: '0xc2Cef51f91dE37739F0a105fEDb058E235BB7354',
-      campaignFactoryAddress: '0x2Af51064E9042E62aB09870B4FDe67a1Ba7FEd69',
-      cappedMilestoneAddress: '0x19Bd4E0DEdb9E5Ee9762391893d1f661404b561f',
-      tokenAddress: '0xb991657107F2F12899938B0985572449400C57d5',
-      etherscan: 'https://rinkeby.etherscan.io/',
-    },
-    develop: {},
-    release: {},
-    alpha: {},
-  },
-  kovan: {
-    master: {
-      title: 'Kovan',
-    },
-  },
-  giveth: {
-    master: {
-      title: 'Giveth',
-      etherscan: 'http://network_explorer.giveth.io/',
-    },
-  },
-};
-
-const replaceWitEnvironmentalVars = network => {
-  network.liquidPledgingAddress =
-    process.env.REACT_APP_LIQUIDPLEDGING_ADDRESS ||
-    network.liquidPledgingAddress;
-  network.dacsAddress =
-    process.env.REACT_APP_DACS_ADDRESS || network.dacsAddress;
-  network.campaignFactoryAddress =
-    process.env.REACT_APP_CAMPAIGN_FACTORY_ADDRESS ||
-    network.campaignFactoryAddress;
-  network.cappedMilestoneAddress =
-    process.env.REACT_APP_CAPPED_MILESTONE_ADDRESS ||
-    network.cappedMilestoneAddress;
-  network.tokenAddress =
-    process.env.REACT_APP_TOKEN_ADDRESS || network.tokenAddress;
-  network.etherscan = process.env.REACT_APP_BLOCKEXPLORER || network.etherscan;
-};
+import config from '../../configuration';
 
 let network;
 
 export default () => {
   if (network) return Promise.resolve(network);
 
-  return getWeb3().then(web3 =>
-    web3.eth.net.getId().then(id => {
-      let networkName = 'default';
-      const environmentName = process.env.REACT_APP_ENVIRONMENT || 'master';
-      switch (id) {
-        case 1:
-          networkName = 'main';
-          break;
-        case 2:
-          networkName = 'morden';
-          break;
-        case 3:
-          networkName = 'ropsten';
-          break;
-        case 4:
-          networkName = 'rinkeby';
-          break;
-        case 33:
-          networkName = 'giveth';
-          break;
-        case 42:
-          networkName = 'kovan';
-          break;
-        default:
-          networkName = 'testrpc';
-          break;
-      }
+  return getWeb3().then(web3 => {
+    network = Object.assign({}, config);
+    network.liquidPledging = new LiquidPledging(
+      web3,
+      network.liquidPledgingAddress,
+    );
+    network.lppDacs = new LPPDacs(web3, network.dacsAddress);
 
-      /**
-       * Merge the networks in the following order:
-       *
-       * 1. Default empty networks
-       * 2. Master environment/branch for chosen networks
-       * 3. Chosen environment/branch for chosen network
-       * 4. Network with values defined in the environment variable
-       */
-      network = Object.assign(
-        {},
-        networks.default.master,
-        networks[networkName].master,
-        networks[networkName][environmentName],
-      );
-      replaceWitEnvironmentalVars(network);
-
-      network.environment = environmentName;
-      network.liquidPledging = new LiquidPledging(
-        web3,
-        network.liquidPledgingAddress,
-      );
-      network.lppDacs = new LPPDacs(web3, network.dacsAddress);
-
-      console.log(network);
-      return network;
-    }),
-  );
+    return network;
+  });
 };

--- a/src/lib/blockchain/getNetwork.js
+++ b/src/lib/blockchain/getNetwork.js
@@ -2,6 +2,7 @@ import { LiquidPledging } from 'giveth-liquidpledging-token';
 import { LPPDacs } from 'lpp-dacs';
 import getWeb3 from './getWeb3';
 
+// The networks look like sparse 2D matrix organised as [networkName][environmentName]
 const networks = {
   default: {
     master: {

--- a/src/lib/blockchain/getWeb3.js
+++ b/src/lib/blockchain/getWeb3.js
@@ -2,6 +2,7 @@ import { MiniMeToken } from 'minimetoken';
 import Web3 from 'web3';
 import ZeroClientProvider from './ZeroClientProvider';
 import getNetwork from './getNetwork';
+import config from '../../configuration';
 
 let givethWeb3;
 /* ///////////// custom Web3 Functions ///////////// */
@@ -43,14 +44,13 @@ function setWallet(wallet) {
         const { tokenAddress } = network;
         const addr = wallet.getAddresses()[0];
 
-        const tokenBal = () => addr
-          ? new MiniMeToken(web3, tokenAddress).balanceOf(addr)
-          : undefined;
-        const bal = () => addr
-          ? web3.eth.getBalance(addr)
-          : undefined;
+        const tokenBal = () =>
+          addr
+            ? new MiniMeToken(web3, tokenAddress).balanceOf(addr)
+            : undefined;
+        const bal = () => (addr ? web3.eth.getBalance(addr) : undefined);
 
-        return Promise.all([tokenBal(), bal()])
+        return Promise.all([tokenBal(), bal()]);
       })
       .then(([tokenBalance, balance]) => {
         wallet.balance = balance;
@@ -71,7 +71,7 @@ function setWallet(wallet) {
 const getWeb3 = () =>
   new Promise(resolve => {
     if (!givethWeb3) {
-      givethWeb3 = new Web3(process.env.REACT_APP_ETH_NODE_CONNECTION_URL);
+      givethWeb3 = new Web3(config.nodeConnection);
 
       // hack to keep the ws connection from timing-out
       // I commented this out b/c we have the getBalance interval above

--- a/src/lib/feathersClient.js
+++ b/src/lib/feathersClient.js
@@ -5,10 +5,11 @@ import io from 'socket.io-client/dist/socket.io';
 import auth from 'feathers-authentication-client';
 import localforage from 'localforage';
 import rx from 'feathers-reactive';
+import config from '../configuration';
 
 import matcher from './matcher';
 
-export const socket = io(process.env.REACT_APP_FEATHERJS_CONNECTION_URL, {
+export const socket = io(config.feathersConnection, {
   transports: ['websocket'],
 });
 


### PR DESCRIPTION
Network environment is now configurable. Optional variable: REACT_APP_ENVIRONMENT can now be configured to switch between different deployment environments (defaults to master, but foreseen options are: master, develop, release, alpha).

All the network values, can however be configured and overwritten through the environment variables as well:
REACT_APP_LIQUIDPLEDGING_ADDRESS
REACT_APP_DACS_ADDRESS
REACT_APP_CAMPAIGN_FACTORY_ADDRESS
REACT_APP_CAPPED_MILESTONE_ADDRESS
REACT_APP_TOKEN_ADDRESS
REACT_APP_BLOCKEXPLORER

I was overengineering the configuration solution, so I have decided to just modify the existing code.