### PR TITLE
changed table-container overflow in _dashboard.css

### DIFF
--- a/src/styles/_dashboard.scss
+++ b/src/styles/_dashboard.scss
@@ -1,7 +1,7 @@
 .dashboard-table-view {
 
   .table-container {
-    overflow: scroll;
+    overflow: auto;
   }
 
   table {


### PR DESCRIPTION
Managed to build and run feathers and the DApp locally, however had some wallet problems, so I did not test much further than checking that the problem is fixed. 

Testing in console showed that also on smaller sizes scroll stays intact because the table is scrollable itself.