### PR TITLE
Upgrade to React 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "react-addons-shallow-compare": "^15.6.0",
     "react-avatar": "^2.3.0",
     "react-cropper": "^1.0.1",
-    "react-datepicker": "^0.54.0",
+    "react-datepicker": "1.4.1",
     "react-dom": "16.3.1",
     "react-html-parser": "^2.0.2",
     "react-input-token": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "react-responsive-masonry": "^1.5.0",
     "react-router": "^4.1.2",
     "react-router-dom": "^4.1.2",
-    "react-skylight": "^0.4.2",
+    "react-skylight": "0.5.1",
     "react-toastify": "2.1.7",
     "react-toggle": "^4.0.2",
     "socket.io-client": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "react-avatar": "^2.3.0",
     "react-cropper": "^1.0.1",
     "react-datepicker": "^0.54.0",
-    "react-dom": "^15.6.1",
+    "react-dom": "16.3.1",
     "react-html-parser": "^2.0.2",
     "react-input-token": "^1.1.2",
     "react-js-pagination": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "dependencies": {
     "bignumber.js": "^6.0.0",
-    "create-react-class": "^15.6.0",
     "feathers": "^2.2.3",
     "feathers-authentication-client": "^0.3.3",
     "feathers-client": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "node-sass-chokidar": "^0.0.3",
     "npm-run-all": "^4.0.2",
     "prop-types": "^15.5.10",
-    "react": "^15.6.1",
+    "react": "16.3.1",
     "react-addons-shallow-compare": "^15.6.0",
     "react-avatar": "^2.3.0",
     "react-cropper": "^1.0.1",
@@ -61,8 +61,8 @@
     "eslint-loader": "^1.9.0",
     "eslint-plugin-import": "^2.8.0",
     "eslint-plugin-jsx-a11y": "^6.0.2",
-    "eslint-plugin-react": "^7.4.0",
     "eslint-plugin-prettier": "^2.4.0",
+    "eslint-plugin-react": "^7.4.0",
     "lerna": "^2.2.0",
     "prettier": "1.9.2"
   },

--- a/src/components/AddMilestoneItem.jsx
+++ b/src/components/AddMilestoneItem.jsx
@@ -1,158 +1,28 @@
 import React, { Component } from 'react';
-import { Portal } from 'react-portal';
-import { utils } from 'web3';
 import PropTypes from 'prop-types';
 
-import { SkyLightStateless } from 'react-skylight';
-import { Input, Form } from 'formsy-react-components';
-import FormsyImageUploader from './FormsyImageUploader';
-import RateConvertor from './RateConvertor';
-
-import { getStartOfDayUTC } from '../lib/helpers';
-
-const initialState = {
-  modalVisible: false,
-  date: getStartOfDayUTC().subtract(1, 'd'),
-  description: '',
-  image: '',
-  uploadNewImage: false,
-  formIsValid: false,
-};
-
-const addMilestoneModalStyle = {
-  width: '70% !important',
-  height: '700px !important',
-  marginTop: '-350px',
-  maxHeight: '700px',
-  overflowY: 'scroll',
-  textAlign: 'left',
-};
 
 class AddMilestoneItem extends Component {
-  constructor(props) {
-    super(props);
-
-    this.state = initialState;
-
-    this.setImage = this.setImage.bind(this);
-    this.submit = this.submit.bind(this);
-    this.openDialog = this.openDialog.bind(this);
-  }
-
-  setImage(image) {
-    this.setState({ image });
-  }
-
-  mapInputs(inputs) {
-    return {
-      date: inputs.date.format(),
-      description: inputs.description,
-      image: this.state.image,
-      selectedFiatType: inputs.fiatType,
-      fiatAmount: inputs.fiatAmount,
-      etherAmount: inputs.etherAmount,
-      wei: utils.toWei(inputs.etherAmount),
-      conversionRate: parseFloat(inputs.conversionRate),
-      ethConversionRateTimestamp: inputs.ethConversionRateTimestamp,
-    };
-  }
-
-  closeDialog() {
-    this.setState(initialState);
-  }
-
-  submit(model) {
-    this.props.onAddItem(model);
-    this.setState(initialState);
-  }
-
-  openDialog() {
-    this.setState({ modalVisible: true });
-  }
 
   render() {
-    const { modalVisible, formIsValid, description, image } = this.state;
-
+    const { onClick } = this.props;
     return (
       <div className="add-milestone-item">
         <button
           type="button"
           className="btn btn-primary btn-sm btn-add-milestone-item"
-          onClick={this.openDialog}
+          onClick={onClick}
         >
           Add item
         </button>
 
-        <Portal className="add-milestone-item-skylight">
-        {modalVisible && (
-          <SkyLightStateless
-            isVisible={modalVisible}
-            onCloseClicked={() => this.closeDialog()}
-            title="Add an item to this milestone"
-            dialogStyles={addMilestoneModalStyle}
-          >
-            <Form
-              onSubmit={this.submit}
-              mapping={inputs => this.mapInputs(inputs)}
-              onValid={() => this.setState({ formIsValid: true })}
-              onInvalid={() => this.setState({ formIsValid: false })}
-              layout="vertical"
-            >
-              <div className="form-group row">
-                <div className="col-12">
-                  <Input
-                    label="Description"
-                    name="description"
-                    type="text"
-                    value={description}
-                    placeholder="E.g. my receipt"
-                    validations="minLength:3"
-                    validationErrors={{
-                      minLength: 'Provide description',
-                    }}
-                    required
-                    autoFocus
-                  />
-                </div>
-              </div>
-
-              <RateConvertor getEthConversion={this.props.getEthConversion} />
-
-              <FormsyImageUploader
-                name="image"
-                previewImage={image}
-                setImage={this.setImage}
-                resize={false}
-              />
-
-              <button
-                className="btn btn-primary"
-                disabled={!formIsValid}
-                formNoValidate
-                type="submit"
-              >
-                Add item
-              </button>
-
-              <button className="btn btn-link" onClick={() => this.closeDialog()}>
-                Cancel
-              </button>
-            </Form>
-          </SkyLightStateless>
-        )}
-        </Portal>
       </div>
     );
   }
 }
 
 AddMilestoneItem.propTypes = {
-  getEthConversion: PropTypes.func.isRequired,
-  onAddItem: PropTypes.func,
-};
-
-AddMilestoneItem.defaultProps = {
-  onAddItem: () => {},
+  onClick: PropTypes.func.isRequired,
 };
 
 export default AddMilestoneItem;

--- a/src/components/AddMilestoneItem.jsx
+++ b/src/components/AddMilestoneItem.jsx
@@ -29,8 +29,8 @@ const addMilestoneModalStyle = {
 };
 
 class AddMilestoneItem extends Component {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
 
     this.state = initialState;
 
@@ -84,6 +84,7 @@ class AddMilestoneItem extends Component {
         </button>
 
         <Portal className="add-milestone-item-skylight">
+        {modalVisible && (
           <SkyLightStateless
             isVisible={modalVisible}
             onCloseClicked={() => this.closeDialog()}
@@ -138,6 +139,7 @@ class AddMilestoneItem extends Component {
               </button>
             </Form>
           </SkyLightStateless>
+        )}
         </Portal>
       </div>
     );

--- a/src/components/AddMilestoneItem.jsx
+++ b/src/components/AddMilestoneItem.jsx
@@ -1,24 +1,19 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 
-
-class AddMilestoneItem extends Component {
-
-  render() {
-    const { onClick } = this.props;
-    return (
-      <div className="add-milestone-item">
-        <button
-          type="button"
-          className="btn btn-primary btn-sm btn-add-milestone-item"
-          onClick={onClick}
-        >
-          Add item
-        </button>
-
-      </div>
-    );
-  }
+function AddMilestoneItem(props) {
+  const { onClick } = props;
+  return (
+    <div className="add-milestone-item">
+      <button
+        type="button"
+        className="btn btn-primary btn-sm btn-add-milestone-item"
+        onClick={onClick}
+      >
+        Add item
+      </button>
+    </div>
+  );
 }
 
 AddMilestoneItem.propTypes = {

--- a/src/components/AddMilestoneItemModal.jsx
+++ b/src/components/AddMilestoneItemModal.jsx
@@ -1,12 +1,12 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { getStartOfDayUTC } from '../lib/helpers';
 import { SkyLightStateless } from 'react-skylight';
 import { Input, Form } from 'formsy-react-components';
-import FormsyImageUploader from './FormsyImageUploader';
-import RateConvertor from './RateConvertor';
 import { utils } from 'web3';
 import { Portal } from 'react-portal';
+import { getStartOfDayUTC } from '../lib/helpers';
+import FormsyImageUploader from './FormsyImageUploader';
+import RateConvertor from './RateConvertor';
 
 const addMilestoneModalStyle = {
   width: '70% !important',
@@ -26,14 +26,20 @@ const initialState = {
 };
 
 export default class AddMilestoneItemModal extends Component {
+  constructor(props) {
+    super(props);
+    this.state = initialState;
+    this.setImage = this.setImage.bind(this);
+    this.mapInputs = this.mapInputs.bind(this);
+    this.closeDialog = this.closeDialog.bind(this);
+    this.submit = this.submit.bind(this);
+  }
 
-  state = initialState
-
-  setImage = (image) => {
+  setImage(image) {
     this.setState({ image });
   }
 
-  mapInputs = (inputs) => {
+  mapInputs(inputs) {
     return {
       date: inputs.date.format(),
       description: inputs.description,
@@ -47,79 +53,79 @@ export default class AddMilestoneItemModal extends Component {
     };
   }
 
-  closeDialog = () => {
+  closeDialog() {
     this.props.onClose();
     this.setState(initialState);
   }
 
-  submit = (model) => {
+  submit(model) {
     this.props.onAddItem(model);
     this.setState(initialState);
   }
 
   render() {
     const { visible } = this.props;
-    const {  formIsValid, description, image } = this.state;
+    const { formIsValid, description, image } = this.state;
     return (
       <Portal className="add-milestone-item-skylight">
-      {visible && (
-        <SkyLightStateless
-          isVisible={visible}
-          onCloseClicked={this.closeDialog}
-          title="Add an item to this milestone"
-          dialogStyles={addMilestoneModalStyle}
-        >
-          <Form
-            onSubmit={this.submit}
-            mapping={this.mapInputs}
-            onValid={() => this.setState({ formIsValid: true })}
-            onInvalid={() => this.setState({ formIsValid: false })}
-            layout="vertical"
+        {visible && (
+          <SkyLightStateless
+            isVisible={visible}
+            onCloseClicked={this.closeDialog}
+            title="Add an item to this milestone"
+            dialogStyles={addMilestoneModalStyle}
           >
-            <div className="form-group row">
-              <div className="col-12">
-                <Input
-                  label="Description"
-                  name="description"
-                  type="text"
-                  value={description}
-                  placeholder="E.g. my receipt"
-                  validations="minLength:3"
-                  validationErrors={{
-                    minLength: 'Provide description',
-                  }}
-                  required
-                  autoFocus
-                />
-              </div>
-            </div>
-
-            <RateConvertor getEthConversion={this.props.getEthConversion} />
-
-            <FormsyImageUploader
-              name="image"
-              previewImage={image}
-              setImage={this.setImage}
-              resize={false}
-            />
-
-            <button
-              className="btn btn-primary"
-              disabled={!formIsValid}
-              formNoValidate
-              type="submit"
+            <Form
+              onSubmit={this.submit}
+              mapping={this.mapInputs}
+              onValid={() => this.setState({ formIsValid: true })}
+              onInvalid={() => this.setState({ formIsValid: false })}
+              layout="vertical"
             >
-              Add item
-            </button>
+              <div className="form-group row">
+                <div className="col-12">
+                  <Input
+                    label="Description"
+                    name="description"
+                    type="text"
+                    value={description}
+                    placeholder="E.g. my receipt"
+                    validations="minLength:3"
+                    validationErrors={{
+                      minLength: 'Provide description',
+                    }}
+                    required
+                    autoFocus
+                  />
+                </div>
+              </div>
 
-            <button className="btn btn-link" onClick={() => this.closeDialog()}>
-              Cancel
-            </button>
-          </Form>
-        </SkyLightStateless>
-      )}
+              <RateConvertor getEthConversion={this.props.getEthConversion} />
+
+              <FormsyImageUploader
+                name="image"
+                previewImage={image}
+                setImage={this.setImage}
+                resize={false}
+              />
+
+              <button
+                className="btn btn-primary"
+                disabled={!formIsValid}
+                formNoValidate
+                type="submit"
+              >
+                Add item
+              </button>
+
+              <button className="btn btn-link" onClick={() => this.closeDialog()}>
+                Cancel
+              </button>
+            </Form>
+          </SkyLightStateless>
+        )}
       </Portal>
-    )
+    );
   }
 }
 
@@ -128,4 +134,4 @@ AddMilestoneItemModal.propTypes = {
   onClose: PropTypes.func.isRequired,
   getEthConversion: PropTypes.func.isRequired,
   onAddItem: PropTypes.func.isRequired,
-}
+};

--- a/src/components/AddMilestoneItemModal.jsx
+++ b/src/components/AddMilestoneItemModal.jsx
@@ -1,0 +1,131 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { getStartOfDayUTC } from '../lib/helpers';
+import { SkyLightStateless } from 'react-skylight';
+import { Input, Form } from 'formsy-react-components';
+import FormsyImageUploader from './FormsyImageUploader';
+import RateConvertor from './RateConvertor';
+import { utils } from 'web3';
+import { Portal } from 'react-portal';
+
+const addMilestoneModalStyle = {
+  width: '70% !important',
+  height: '700px !important',
+  marginTop: '-350px',
+  maxHeight: '700px',
+  overflowY: 'scroll',
+  textAlign: 'left',
+};
+
+const initialState = {
+  date: getStartOfDayUTC().subtract(1, 'd'),
+  description: '',
+  image: '',
+  uploadNewImage: false,
+  formIsValid: false,
+};
+
+export default class AddMilestoneItemModal extends Component {
+
+  state = initialState
+
+  setImage = (image) => {
+    this.setState({ image });
+  }
+
+  mapInputs = (inputs) => {
+    return {
+      date: inputs.date.format(),
+      description: inputs.description,
+      image: this.state.image,
+      selectedFiatType: inputs.fiatType,
+      fiatAmount: inputs.fiatAmount,
+      etherAmount: inputs.etherAmount,
+      wei: utils.toWei(inputs.etherAmount),
+      conversionRate: parseFloat(inputs.conversionRate),
+      ethConversionRateTimestamp: inputs.ethConversionRateTimestamp,
+    };
+  }
+
+  closeDialog = () => {
+    this.props.onClose();
+    this.setState(initialState);
+  }
+
+  submit = (model) => {
+    this.props.onAddItem(model);
+    this.setState(initialState);
+  }
+
+  render() {
+    const { visible } = this.props;
+    const {  formIsValid, description, image } = this.state;
+    return (
+      <Portal className="add-milestone-item-skylight">
+      {visible && (
+        <SkyLightStateless
+          isVisible={visible}
+          onCloseClicked={this.closeDialog}
+          title="Add an item to this milestone"
+          dialogStyles={addMilestoneModalStyle}
+        >
+          <Form
+            onSubmit={this.submit}
+            mapping={this.mapInputs}
+            onValid={() => this.setState({ formIsValid: true })}
+            onInvalid={() => this.setState({ formIsValid: false })}
+            layout="vertical"
+          >
+            <div className="form-group row">
+              <div className="col-12">
+                <Input
+                  label="Description"
+                  name="description"
+                  type="text"
+                  value={description}
+                  placeholder="E.g. my receipt"
+                  validations="minLength:3"
+                  validationErrors={{
+                    minLength: 'Provide description',
+                  }}
+                  required
+                  autoFocus
+                />
+              </div>
+            </div>
+
+            <RateConvertor getEthConversion={this.props.getEthConversion} />
+
+            <FormsyImageUploader
+              name="image"
+              previewImage={image}
+              setImage={this.setImage}
+              resize={false}
+            />
+
+            <button
+              className="btn btn-primary"
+              disabled={!formIsValid}
+              formNoValidate
+              type="submit"
+            >
+              Add item
+            </button>
+
+            <button className="btn btn-link" onClick={() => this.closeDialog()}>
+              Cancel
+            </button>
+          </Form>
+        </SkyLightStateless>
+      )}
+      </Portal>
+    )
+  }
+}
+
+AddMilestoneItemModal.propTypes = {
+  visible: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  getEthConversion: PropTypes.func.isRequired,
+  onAddItem: PropTypes.func.isRequired,
+}

--- a/src/components/views/EditMilestone.jsx
+++ b/src/components/views/EditMilestone.jsx
@@ -35,6 +35,8 @@ import User from '../../models/User';
 import GivethWallet from '../../lib/blockchain/GivethWallet';
 import MilestoneItem from '../../components/MilestoneItem';
 import AddMilestoneItem from '../../components/AddMilestoneItem';
+import AddMilestoneItemModal from '../../components/AddMilestoneItemModal';
+
 
 BigNumber.config({ DECIMAL_PLACES: 18 });
 
@@ -50,8 +52,8 @@ BigNumber.config({ DECIMAL_PLACES: 18 });
  *    id (string): an id of a milestone object
  */
 class EditMilestone extends Component {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
 
     this.state = {
       isLoading: true,
@@ -231,7 +233,7 @@ class EditMilestone extends Component {
     });
   }
 
-  getEthConversion(date) {
+  getEthConversion = (date) => {
     const dtUTC = getStartOfDayUTC(date); // Should not be necessary as the datepicker should provide UTC, but just to be sure
     const timestamp = Math.round(dtUTC.toDate()) / 1000;
 
@@ -291,7 +293,7 @@ class EditMilestone extends Component {
     return 'Update Milestone';
   }
 
-  addItem(item) {
+  addItem = (item) => {
     this.setState({ items: this.state.items.concat(item) });
   }
 
@@ -312,7 +314,8 @@ class EditMilestone extends Component {
     };
   }
 
-  toggleItemize() {
+  toggleItemize = () => {
+    console.log(this.state.itemizeState);
     this.setState({ itemizeState: !this.state.itemizeState });
   }
 
@@ -721,7 +724,7 @@ class EditMilestone extends Component {
                       <Toggle
                         id="itemize-state"
                         defaultChecked={this.state.itemizeState}
-                        onChange={() => this.toggleItemize()}
+                        onChange={this.toggleItemize}
                         disabled={!isNew && !isProposed}
                       />
                       <span className="label">Add multiple expenses, invoices or items</span>
@@ -842,9 +845,7 @@ class EditMilestone extends Component {
                               {items.length > 0 &&
                                 (isNew || isProposed) && (
                                   <AddMilestoneItem
-                                    onAddItem={item => this.addItem(item)}
-                                    getEthConversion={dt => this.getEthConversion(dt)}
-                                    fiatTypes={fiatTypes}
+                                    onClick={this.toggleAddMilestoneItemModal}
                                   />
                                 )}
 
@@ -856,9 +857,7 @@ class EditMilestone extends Component {
                                       anything else that needs to be paid.
                                     </p>
                                     <AddMilestoneItem
-                                      onAddItem={item => this.addItem(item)}
-                                      getEthConversion={dt => this.getEthConversion(dt)}
-                                      fiatTypes={fiatTypes}
+                                      onClick={this.toggleAddMilestoneItemModal}
                                     />
                                   </div>
                                 )}
@@ -891,8 +890,25 @@ class EditMilestone extends Component {
             </div>
           </div>
         </div>
+        <AddMilestoneItemModal
+          visible={this.state.addMilestoneItemModalVisible}
+          onClose={this.toggleAddMilestoneItemModal}
+          getEthConversion={this.getEthConversion}
+          onAddItem={this.onAddItem}
+          fiatTypes={fiatTypes}
+        />
       </div>
     );
+  }
+
+  toggleAddMilestoneItemModal = () =>
+    this.setState({
+      addMilestoneItemModalVisible: !this.state.addMilestoneItemModalVisible
+    })
+
+  onAddItem = (item) => {
+    this.addItem(item);
+    this.setState({ addMilestoneItemModalVisible: false });
   }
 }
 

--- a/src/components/views/EditMilestone.jsx
+++ b/src/components/views/EditMilestone.jsx
@@ -727,7 +727,7 @@ class EditMilestone extends Component {
                       <span className="label">Add multiple expenses, invoices or items</span>
                     </div>
 
-                    {!itemizeState && (
+                    {!itemizeState ? (
                       <div className="card milestone-items-card">
                         <div className="card-body">
                           <div className="form-group row">
@@ -806,9 +806,7 @@ class EditMilestone extends Component {
                           </div>
                         </div>
                       </div>
-                    )}
-
-                    {itemizeState && (
+                    ) : (
                       <div className="form-group row dashboard-table-view">
                         <div className="col-12">
                           <div className="card milestone-items-card">

--- a/src/components/views/EditMilestone.jsx
+++ b/src/components/views/EditMilestone.jsx
@@ -285,6 +285,18 @@ class EditMilestone extends Component {
     }
   }
 
+  addItem(item) {
+    this.setState({ items: this.state.items.concat(item) });
+  }
+
+  btnText() {
+    if (this.props.isNew) {
+      return this.props.isProposed ? 'Propose Milestone' : 'Create Milestone';
+    }
+
+    return 'Update Milestone';
+  }
+
   removeItem(index) {
     const { items } = this.state;
     delete items[index];

--- a/yarn.lock
+++ b/yarn.lock
@@ -8041,9 +8041,9 @@ react-router@^4.1.2, react-router@^4.2.0:
     prop-types "^15.5.4"
     warning "^3.0.0"
 
-react-skylight@^0.4.2:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/react-skylight/-/react-skylight-0.4.2.tgz#939b8972705ccd39fda3186e34708010e0b1cf17"
+react-skylight@0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/react-skylight/-/react-skylight-0.5.1.tgz#bf7f9d7f2929a83fe16cac8edacdeda025218d40"
   dependencies:
     prop-types "^15.5.10"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6567,7 +6567,7 @@ modify-values@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.0.tgz#e2b6cdeb9ce19f99317a53722f3dbf5df5eaaab2"
 
-moment@^2.17.1, moment@^2.19.2, moment@^2.6.0:
+moment@^2.19.2, moment@^2.6.0:
   version "2.20.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.20.1.tgz#d6eb1a46cbcc14a2b2f9434112c1ff8907f313fd"
 
@@ -7292,9 +7292,9 @@ pluralize@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
 
-popper.js@^1.12.5:
-  version "1.12.9"
-  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.12.9.tgz#0dfbc2dff96c451bb332edcfcfaaf566d331d5b3"
+popper.js@^1.14.1:
+  version "1.14.3"
+  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.14.3.tgz#1438f98d046acf7b4d78cd502bf418ac64d4f095"
 
 portfinder@^1.0.9:
   version "1.0.13"
@@ -7694,7 +7694,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-"prop-types@15.x.x - 16.x.x":
+"prop-types@15.x.x - 16.x.x", prop-types@^15.6.1:
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
   dependencies:
@@ -7903,15 +7903,14 @@ react-cropper@^1.0.1:
     cropperjs v1.0.0-rc.3
     prop-types "^15.5.8"
 
-react-datepicker@^0.54.0:
-  version "0.54.0"
-  resolved "https://registry.yarnpkg.com/react-datepicker/-/react-datepicker-0.54.0.tgz#b70949c1c6fde96cc06e7062c42c38eaeb5d568d"
+react-datepicker@1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/react-datepicker/-/react-datepicker-1.4.1.tgz#ee171b71d9853e56f9eece5fc3186402f4648683"
   dependencies:
     classnames "^2.2.5"
-    moment "^2.17.1"
-    prop-types "^15.5.8"
-    react-onclickoutside "^6.1.1"
-    react-popper "^0.7.2"
+    prop-types "^15.6.0"
+    react-onclickoutside "^6.7.1"
+    react-popper "^0.9.1"
 
 react-dev-utils@^3.1.0:
   version "3.1.1"
@@ -7986,16 +7985,16 @@ react-js-pagination@^3.0.1:
     prop-types "15.x.x - 16.x.x"
     react "15.x.x - 16.x.x"
 
-react-onclickoutside@^6.1.1:
+react-onclickoutside@^6.7.1:
   version "6.7.1"
   resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-6.7.1.tgz#6a5b5b8b4eae6b776259712c89c8a2b36b17be93"
 
-react-popper@^0.7.2:
-  version "0.7.5"
-  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-0.7.5.tgz#71c25946f291db381231281f6b95729e8b801596"
+react-popper@^0.9.1:
+  version "0.9.5"
+  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-0.9.5.tgz#02a24ef3eec33af9e54e8358ab70eb0e331edd05"
   dependencies:
-    popper.js "^1.12.5"
-    prop-types "^15.5.10"
+    popper.js "^1.14.1"
+    prop-types "^15.6.1"
 
 react-portal@^4.1.2:
   version "4.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8085,7 +8085,16 @@ react-transition-group@^2.2.1:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
-react@^15.4.2, react@^15.6.1:
+react@16.3.1:
+  version "16.3.1"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.3.1.tgz#4a2da433d471251c69b6033ada30e2ed1202cfd8"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
+
+react@^15.4.2:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/react/-/react-15.6.2.tgz#dba0434ab439cfe82f108f0f511663908179aa72"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -7941,14 +7941,14 @@ react-dom-factories@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/react-dom-factories/-/react-dom-factories-1.0.2.tgz#eb7705c4db36fb501b3aa38ff759616aa0ff96e0"
 
-react-dom@^15.6.1:
-  version "15.6.2"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.6.2.tgz#41cfadf693b757faf2708443a1d1fd5a02bef730"
+react-dom@16.3.1:
+  version "16.3.1"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.3.1.tgz#6a3c90a4fb62f915bdbcf6204422d93a7d4ca573"
   dependencies:
-    fbjs "^0.8.9"
+    fbjs "^0.8.16"
     loose-envify "^1.1.0"
-    object-assign "^4.1.0"
-    prop-types "^15.5.10"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
 
 react-error-overlay@^1.0.10:
   version "1.0.10"


### PR DESCRIPTION
I wanted a feedback about `react-input-token` cause it's the only component left using `react@15`, as reported by running `yarn list react`

```
$yarn list react
yarn list v1.6.0
warning Filtering by arguments is deprecated. Please use the pattern option instead.
├─ react-input-token@1.1.2
│  └─ react@15.6.2
├─ react-js-pagination@3.0.1
│  └─ react@16.2.0
└─ react@16.3.1
✨  Done in 1.27s.
```

The component seems to be unmaintained, so it could be rewritten and included in the code base as it is quite small.

Let me know what do you think