### PR TITLE
Campaign managers can also edit milestones now. Fixes #284

### DIFF
--- a/src/components/views/EditMilestone.jsx
+++ b/src/components/views/EditMilestone.jsx
@@ -134,7 +134,12 @@ class EditMilestone extends Component {
               milestone.maxAmount = new BigNumber(milestone.maxAmount);
               milestone.fiatAmount = new BigNumber(milestone.fiatAmount);
 
-              if (!isOwner(milestone.owner.address, this.props.currentUser)) {
+              if (
+                !(
+                  isOwner(milestone.owner.address, this.props.currentUser) ||
+                  isOwner(milestone.campaignOwnerAddress, this.props.currentUser)
+                )
+              ) {
                 this.props.history.goBack();
               }
               this.setState(

--- a/src/components/views/MyMilestones.jsx
+++ b/src/components/views/MyMilestones.jsx
@@ -861,14 +861,12 @@ class MyMilestones extends Component {
                                     )}
                                 </td>
                                 <td className="td-actions">
-                                  {m.ownerAddress === currentUser.address &&
-                                    [
-                                      'proposed',
-                                      'rejected',
-                                      'InProgress',
-                                      'NeedReview',
-                                      'InReview',
-                                    ].includes(m.status) && (
+                                  {/* Campaign and Milestone managers can edit milestone */}
+                                  {(m.ownerAddress === currentUser.address ||
+                                    m.campaign.ownerAddress === currentUser.address) &&
+                                    ['proposed', 'rejected', 'InProgress', 'NeedsReview'].includes(
+                                      m.status,
+                                    ) && (
                                       <button
                                         className="btn btn-link"
                                         onClick={() => this.editMilestone(m)}


### PR DESCRIPTION
Should be only merged after https://github.com/Giveth/feathers-giveth/pull/85 as otherwise it allows campaign managers to take ownership of milestones.