### PR TITLE
Fixes #441: Limit cropping area to the image size

### DIFF
--- a/src/components/FormsyImageUploader.jsx
+++ b/src/components/FormsyImageUploader.jsx
@@ -84,6 +84,7 @@ class FormsyImageUploader extends Component {
                   highlight={false}
                   autoCropArea={1}
                   zoomOnWheel={false}
+                  viewMode={1}
                 />
               </div>
             </div>


### PR DESCRIPTION
Just looked into the documentation of the react-cropper component and got this fix.

Please see @vojtechsimetka 