### PR TITLE
Solved Image is too damn small! Make images fit to width

### DIFF
--- a/src/styles/_layout.scss
+++ b/src/styles/_layout.scss
@@ -3,7 +3,7 @@
 
 @mixin make-flex() {
   display: flex;
-  flex-direction: row;    
+  flex-direction: row;
 }
 
 .vertical-align {
@@ -11,24 +11,31 @@
   align-items: center;
   justify-content: center;
   width: 100%;
-}  
-
+}
 
 @mixin content-styling() {
   .content {
     font-size: 1.2rem;
-    
+
     iframe,
     img {
-      max-width: 100%;
-      max-height: 300px; 
+      @media (max-width: 576px) {
+        max-width: 600px;
+        max-height: 600px;
+      }
+
+      @media (min-width: 768px) {
+        max-width: 1200px;
+        max-height: 1200px;
+      }
+
       width: 100%;
       height: 100%;
 
       &.cause-header-image {
         margin-bottom: 30px;
         border-radius: 3px;
-      }   
+      }
     }
 
     @media (max-width: 768px) {


### PR DESCRIPTION
This PR is to solve the issue #440, the problem is that has a max-height in _layout.scss, what I did is to add a media querie and fit the image size according to screen, to not make destortion in image. 

a screenshot of the problem solved:

![teste](https://user-images.githubusercontent.com/18357049/45785659-8a10fd00-bc43-11e8-947a-736614e8e6b8.png)
