### PR TITLE
Fixes #475: Milestones that have no funding get marked complete and then can't receive funding

### DIFF
--- a/src/components/views/ViewDAC.jsx
+++ b/src/components/views/ViewDAC.jsx
@@ -105,7 +105,7 @@ class ViewDAC extends Component {
               />
               {dac.communityUrl && (
                 <CommunityButton className="btn btn-secondary" url={dac.communityUrl}>
-                  Join our community
+                  &nbsp;Join our community
                 </CommunityButton>
               )}
             </BackgroundImageHeader>

--- a/src/components/views/ViewMilestone.jsx
+++ b/src/components/views/ViewMilestone.jsx
@@ -82,7 +82,7 @@ class ViewMilestone extends Component {
   }
 
   isActiveMilestone() {
-    return this.state.status === 'InProgress' && !this.state.fullyFunded;
+    return ['InProgress', 'Completed'].includes(this.state.status) && !this.state.fullyFunded;
   }
 
   editMilestone(e) {


### PR DESCRIPTION
This PR is to close the issue #475 
I've displayed button "DONATE" when milestone have been completed but still not fully funded 