### PR TITLE
Added query strings for milestone cap and reviewer requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@ The following arguments are available:
 | tokenAddress | A valid token address | string |
 | maxAmount | A valid max amount of ETH or token | number |
 | fiatAmount | A valid max amount of fiat (dependant on selectedFiatType) | number |
+| isCapped | Determines whether the milestone should be capped | 0 or 1 (boolean) |
+| requireReviewer | Determines whether the milestone should require a reviewer | 0 or 1 (boolean) |
 
 
 ## Contributing

--- a/src/components/views/EditMilestone.jsx
+++ b/src/components/views/EditMilestone.jsx
@@ -296,8 +296,10 @@ class EditMilestone extends Component {
         milestone.selectedFiatType = milestone.token.symbol;
         rate = resp.rates[milestone.token.symbol];
       }
-      milestone.maxAmount = milestone.fiatAmount.div(rate);
-      milestone.conversionRateTimestamp = resp.timestamp;
+      if (milestone.isCapped) {
+        milestone.maxAmount = milestone.fiatAmount.div(rate);
+        milestone.conversionRateTimestamp = resp.timestamp;
+      }
 
       this.setState({ milestone });
     });

--- a/src/components/views/EditMilestone.jsx
+++ b/src/components/views/EditMilestone.jsx
@@ -55,6 +55,8 @@ const validQueryStringVariables = [
   'token',
   'tokenAddress',
   'maxAmount',
+  'isCapped',
+  'requireReviewer',
   // 'fiatAmount', // FIXME: The fiatAmount does not work because it is overwritten when the getConversionRates function is called. This function modifies th e provider and causes re-render which makes the maxAmount being updated incorrectly. The function needs to change to not update the provider state and not expose currentRate
 ];
 
@@ -179,6 +181,15 @@ class EditMilestone extends Component {
                   if (date.isValid()) milestone.date = date;
                   break;
                 }
+                case 'isCapped':
+                  milestone.maxAmount = qs[variable] === '1' ? new BigNumber(0) : undefined;
+                  if (qs[variable] === '1') {
+                    milestone.fiatAmount = new BigNumber(0);
+                  }
+                  break;
+                case 'requireReviewer':
+                  milestone.reviewerAddress = qs[variable] === '1' ? '' : ZERO_ADDRESS;
+                  break;
                 default:
                   milestone[variable] = qs[variable];
                   break;
@@ -198,14 +209,16 @@ class EditMilestone extends Component {
               milestone.token.symbol,
             );
 
-            const rate = rates[milestone.selectedFiatType];
-            if (rate && (milestone.maxAmount && milestone.maxAmount.gt(0))) {
-              milestone.fiatAmount = milestone.maxAmount.times(rate);
-            } else if (rate && (milestone.fiatAmount && milestone.fiatAmount.gt(0))) {
-              milestone.maxAmount = milestone.fiatAmount.div(rate);
-            } else {
-              milestone.maxAmount = new BigNumber('0');
-              milestone.fiatAmount = new BigNumber('0');
+            if (milestone.isCapped) {
+              const rate = rates[milestone.selectedFiatType];
+              if (rate && (milestone.maxAmount && milestone.maxAmount.gt(0))) {
+                milestone.fiatAmount = milestone.maxAmount.times(rate);
+              } else if (rate && (milestone.fiatAmount && milestone.fiatAmount.gt(0))) {
+                milestone.maxAmount = milestone.fiatAmount.div(rate);
+              } else {
+                milestone.maxAmount = new BigNumber('0');
+                milestone.fiatAmount = new BigNumber('0');
+              }
             }
 
             this.setState({


### PR DESCRIPTION
Expanded query string functionality as needed for RewardDAO automation

Can be tested with example: http://localhost:3010/campaigns/5c7e6e43b670ef31461c17b0/milestones/propose?isCapped=0&requireReviewer=0