### PR TITLE
Closes #679 - Right click Milestones to open in new tab

### DIFF
--- a/src/components/CampaignCard.jsx
+++ b/src/components/CampaignCard.jsx
@@ -17,10 +17,15 @@ class CampaignCard extends Component {
     super(props);
 
     this.viewCampaign = this.viewCampaign.bind(this);
+    this.createCampaignLink = this.createCampaignLink.bind(this);
   }
 
   viewCampaign() {
     history.push(`/campaigns/${this.props.campaign.id}`);
+  }
+
+  createCampaignLink() {
+    return `/campaigns/${this.props.campaign.id}`;
   }
 
   render() {
@@ -30,12 +35,11 @@ class CampaignCard extends Component {
       <div
         className="card overview-card"
         id={campaign.id} // eslint-disable-line no-underscore-dangle
-        onClick={this.viewCampaign}
         onKeyPress={this.viewCampaign}
         role="button"
         tabIndex="0"
       >
-        <div className="card-body">
+        <a className="card-body" href={this.createCampaignLink()}>
           <div className="card-img" style={{ backgroundImage: `url(${campaign.image})` }} />
 
           <div className="card-content">
@@ -52,7 +56,7 @@ class CampaignCard extends Component {
               token={{ symbol: config.nativeTokenName, decimals: 18 }}
             />
           </div>
-        </div>
+        </a>
       </div>
     );
   }

--- a/src/components/DacCard.jsx
+++ b/src/components/DacCard.jsx
@@ -15,10 +15,15 @@ class DacCard extends Component {
     super(props);
 
     this.viewDAC = this.viewDAC.bind(this);
+    this.createDACLink = this.createDACLink.bind(this);
   }
 
   viewDAC() {
     history.push(`/dacs/${this.props.dac.id}`);
+  }
+
+  createDACLink() {
+    return `/dacs/${this.props.dac.id}`;
   }
 
   render() {
@@ -28,12 +33,11 @@ class DacCard extends Component {
       <div
         className="card overview-card"
         id={dac.id}
-        onClick={this.viewDAC}
         onKeyPress={this.viewDAC}
         role="button"
         tabIndex="0"
       >
-        <div className="card-body">
+        <a className="card-body" href={this.createDACLink()}>
           <div className="card-img" style={{ backgroundImage: `url(${dac.image})` }} />
 
           <div className="card-content">
@@ -49,7 +53,7 @@ class DacCard extends Component {
               currentBalance={dac.currentBalance}
             />
           </div>
-        </div>
+        </a>
       </div>
     );
   }

--- a/src/components/MilestoneCard.jsx
+++ b/src/components/MilestoneCard.jsx
@@ -19,12 +19,17 @@ class MilestoneCard extends Component {
     this.viewMilestone = this.viewMilestone.bind(this);
     this.editMilestone = this.editMilestone.bind(this);
     this.viewProfile = this.viewProfile.bind(this);
+    this.createMilestoneLink = this.createMilestoneLink.bind(this);
   }
 
   viewMilestone() {
     history.push(
       `/campaigns/${this.props.milestone.campaign._id}/milestones/${this.props.milestone._id}`,
     );
+  }
+
+  createMilestoneLink() {
+    return `/campaigns/${this.props.milestone.campaign._id}/milestones/${this.props.milestone._id}`;
   }
 
   viewProfile(e) {
@@ -58,7 +63,6 @@ class MilestoneCard extends Component {
     return (
       <div
         className="card milestone-card overview-card"
-        onClick={this.viewMilestone}
         onKeyPress={this.viewMilestone}
         role="button"
         tabIndex="0"
@@ -87,7 +91,9 @@ class MilestoneCard extends Component {
                 </span>
               )}
           </div>
+        </div>
 
+        <a className="card-body" href={this.createMilestoneLink()}>
           <div
             className="card-img"
             style={{
@@ -112,7 +118,7 @@ class MilestoneCard extends Component {
               token={milestone.token}
             />
           </div>
-        </div>
+        </a>
       </div>
     );
   }

--- a/src/styles/_card.scss
+++ b/src/styles/_card.scss
@@ -31,6 +31,7 @@ $aspect-ratio: percentage(9/16); //16:9 ratio
     @include bullet-styling(8);
     box-shadow: 0 0 20px darken($page-background, 10%);
     padding: 0;
+    color: black;
 
     .card-avatar {
       padding: 10px 20px;
@@ -75,6 +76,10 @@ $aspect-ratio: percentage(9/16); //16:9 ratio
       right: 0;   
       border: none;   
     }
+  }
+
+  .card-body:hover {
+    text-decoration: none
   }
 }
 


### PR DESCRIPTION
Closes #679 

To solve this, I switched one of the divs in `DacCard.jsx` with an `<a/>`. Then I added an appropriate `href` to that element. Now that we have a link, you can right-click -> "Open in new tab" 👍  

I also had to change the `_card.scss` styles in order to prevent the default `<a/>` styling from appearing.

![](https://media.giphy.com/media/1iw2Isi9tnKddNbVEY/giphy.gif)
