### PR TITLE
Use createAt time for showing in milestone page

### DIFF
--- a/src/components/views/ViewMilestone.jsx
+++ b/src/components/views/ViewMilestone.jsx
@@ -495,7 +495,7 @@ const ViewMilestone = props => {
                                     : 'The date this Milestone was created'
                                 }
                               />
-                              {moment.utc(milestone.date).format('Do MMM YYYY')}
+                              {moment.utc(milestone.createdAt).format('Do MMM YYYY')}
                             </div>
                           )}
 


### PR DESCRIPTION
related to #1396

I don't know why we used the date instead of createAt in milestone page