### PR TITLE
show appropriate error on create new donation

### DIFF
--- a/src/services/DonationBlockchainService.jsx
+++ b/src/services/DonationBlockchainService.jsx
@@ -807,9 +807,10 @@ class DonationBlockchainService {
       .service('donations')
       .create(newDonation)
       .catch(err => {
-        const message =
-          'Your donation has been initiated, however an error occurred when attempting to save. You should see your donation appear within ~30 mins.';
-        ErrorHandler(err, message);
+        // const message =
+        // 'Your donation has been initiated, however an error occurred when attempting to save. You should see your donation appear within ~30 mins.';
+        console.log('err :>> ', err);
+        ErrorHandler(err, err.name);
       });
   }
 


### PR DESCRIPTION
Show error name instead of static error message to maker finding issue easier.