### PR TITLE
H 2348 When editing traces initial value for descriptions is not set

### DIFF
--- a/src/components/EditTraceCommons.jsx
+++ b/src/components/EditTraceCommons.jsx
@@ -86,6 +86,7 @@ const TraceDescription = ({
       className="custom-form-item"
       extra={extra}
       required
+      initialValue={initialValue}
       rules={[
         {
           type: 'string',

--- a/src/styles/_antOverrides.scss
+++ b/src/styles/_antOverrides.scss
@@ -184,6 +184,16 @@
 	padding-top: 60px;
 }
 
+.ant-notification .ant-notification-notice {
+  line-height: 2;
+}
+
+.ant-message .ant-message-custom-content {
+  display: flex;
+  align-items: center;
+  line-height: 2;
+}
+
 .quill-wrapper {
 	.ql-toolbar{
 		border: 2px solid #dfdae8;


### PR DESCRIPTION
Issue #2348 
1. When editing traces initial value for descriptions is not set
2. Fix Ant notification and message icon not center